### PR TITLE
Fix: Error in generating tool_name due to null value.

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2219,6 +2219,10 @@
                             if (lastTool && (!tool.id || lastTool.id == tool.id)) {
                                 const source = tool.function
                                 for (const key in source) {
+                                    // Determine if source[key] is null, skip if it is null
+                                    if (source[key] === null) {
+                                        continue;
+                                    }
                                     if (lastTool.function[key]) {
                                         lastTool.function[key] += source[key];
                                     } else {


### PR DESCRIPTION
修复由于 null value 拼接导致的 tool_name 错误

相关 issue： #2 